### PR TITLE
Add plugin scaffold with build and test setup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "x-post-sync",
+  "name": "X Post Sync",
+  "version": "1.0.0",
+  "minAppVersion": "0.15.0",
+  "description": "Sync X Posts to your Obsidian.",
+  "author": "Unknown",
+  "authorUrl": "https://example.com",
+  "main": "dist/main.js"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "x-post-sync",
+  "version": "1.0.0",
+  "description": "Sync X Posts to your Obsidian.",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "rollup -c",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^24.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.2",
+    "rollup": "^3.29.4",
+    "rollup-plugin-typescript2": "^0.34.1",
+    "typescript": "^5.2.2",
+    "vitest": "^0.34.1"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,18 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+
+export default {
+  input: 'src/main.ts',
+  output: {
+    dir: 'dist',
+    sourcemap: true,
+    format: 'cjs'
+  },
+  external: ['obsidian'],
+  plugins: [
+    nodeResolve({ browser: true }),
+    commonjs(),
+    typescript()
+  ]
+};

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,8 @@
+export interface Post {
+  author: string;
+  text: string;
+}
+
+export function formatPost(post: Post): string {
+  return `**${post.author}**: ${post.text}`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,32 @@
+import { Plugin } from 'obsidian';
+import { DEFAULT_SETTINGS, XPostSyncSettings, XPostSyncSettingTab } from './settings';
+import { formatPost } from './core';
+
+export default class XPostSyncPlugin extends Plugin {
+  settings: XPostSyncSettings;
+
+  async onload() {
+    await this.loadSettings();
+
+    this.addCommand({
+      id: 'format-post',
+      name: 'Format Sample Post',
+      callback: () => {
+        const result = formatPost({ author: 'Alice', text: 'Hello' });
+        console.log(result);
+      }
+    });
+
+    this.addSettingTab(new XPostSyncSettingTab(this.app, this));
+  }
+
+  onunload() {}
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,36 @@
+import { App, PluginSettingTab, Setting } from 'obsidian';
+
+export interface XPostSyncSettings {
+  apiKey: string;
+}
+
+export const DEFAULT_SETTINGS: XPostSyncSettings = {
+  apiKey: ''
+};
+
+export class XPostSyncSettingTab extends PluginSettingTab {
+  plugin: any;
+
+  constructor(app: App, plugin: any) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('API Key')
+      .setDesc('Key used to authenticate with X API.')
+      .addText(text =>
+        text
+          .setPlaceholder('Enter API key')
+          .setValue(this.plugin.settings.apiKey)
+          .onChange(async (value) => {
+            this.plugin.settings.apiKey = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { formatPost } from '../src/core';
+
+describe('formatPost', () => {
+  it('formats post correctly', () => {
+    const md = formatPost({ author: 'Bob', text: 'Test' });
+    expect(md).toBe('**Bob**: Test');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["DOM", "ES2020"],
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- set up `package.json`, `tsconfig.json`, `rollup.config.js`, and `manifest.json`
- implement plugin source in `src/` with a simple command and settings tab
- add a basic unit test using Vitest

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_684193e494d0832fb6adfda5970b1550